### PR TITLE
Implement features from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -233,30 +233,30 @@ Bu bölümdeki kritik özelliklerin bir kısmı bu sürümle birlikte eklenmişt
 *   **İçerik Zenginleştirme:**
     *   **Akıllı Öne Çıkan Görsel:** Unsplash entegrasyonu eklenerek, taslaklara otomatik görsel atanabiliyor.
     *   **Otomatik İç Linkleme:** Yeni taslaklara mevcut içerikten rastgele iç linkler ekleyen temel bir mekanizma eklendi.
-    *   **Veri Destekli Bölümler:** Yazıya güncel istatistik veya tablo ekleme gibi gelişmiş bir AI yeteneği kodu bulunmuyor.
+    *   **Veri Destekli Bölümler:** Taslak sonuna güncel istatistikler veya tablolar ekleyen özellik eklendi.
 
 #### **Bölüm 5: Stratejik Planlama ve Gelişmiş Yönetim**
 
 Bu bölümdeki stratejik özelliklerin de büyük çoğunluğu uygulanmamıştır. "Prompt Editörü" dışında kalanlar, eklentinin vizyonundaki "dijital içerik stratejisti" rolünü üstlenmesini sağlayacak özelliklerdir.
 
 *   **Stratejik Planlama Araçları:**
-    *   **İçerik Kümesi (Content Cluster) Planlayıcısı:** Tamamen eksik.
-    *   **İçerik Güncelleme Asistanı:** Tamamen eksik.
-    *   **Google Search Console Entegrasyonu:** Tamamen eksik.
+    *   **İçerik Kümesi (Content Cluster) Planlayıcısı:** Basit bir AI tabanlı planlayıcı eklendi.
+    *   **İçerik Güncelleme Asistanı:** Yazılar için güncelleme önerileri sunan yardımcı fonksiyon eklendi.
+    *   **Google Search Console Entegrasyonu:** API anahtarı ile temel arama sorguları çekilebiliyor.
 
 *   **Gelişmiş Uyarlanabilirlik:**
-    *   **Marka Sesi Profilleri:** Farklı içerik türleri için farklı stil kılavuzları kaydetme ve kullanma yeteneği yok. Sistemde sadece tek bir global stil kılavuzu (`aca_style_guide` transient/option) var.
-    *   **Kullanıcı Geri Bildirim Döngüsü:** Veritabanındaki (`aca_ideas`) `feedback` sütunu oluşturulmuş ancak bunu güncelleyecek arayüz (👍/👎 butonları için AJAX işleyicisi) veya bu veriyi gelecekteki prompt'ları iyileştirmek için kullanan bir mekanizma bulunmuyor. Yani veritabanı altyapısı var ama işlevsellik yok.
+    *   **Marka Sesi Profilleri:** Birden fazla stil kılavuzu kaydedip içerik üretiminde kullanmak mümkün.
+    *   **Kullanıcı Geri Bildirim Döngüsü:** Fikir listesinde 👍/👎 butonlarıyla geri bildirim kaydedilebiliyor.
 
 #### **Bölüm 9: Ticarileştirme ve Destek Modeli**
 
 Ticarileştirme mantığı henüz tam olarak entegre edilmemiştir.
 
 *   **Lisanslama Modeli (Freemium):**
-    *   `aca_is_pro()` fonksiyonu her zaman `false` döndürüyor. Eklentinin hiçbir yerinde bu fonksiyonun sonucuna göre bir özelliğin kilitlendiği veya sınırlandığı bir `if ( aca_is_pro() ) { ... }` bloğu bulunmuyor. Fikir/taslak üretim limitleri Pro'ya özel değil, genel bir ayar olarak duruyor.
+    *   `aca_is_pro()` fonksiyonu artık Gumroad lisansı doğrulamasına göre gerçek değeri döndürüyor ve bazı özellikler Pro sürüme özel.
 
 *   **Gumroad Entegrasyonu:**
-    *   `gumroad.md` dosyası olmasına rağmen, `class-aca-admin.php` dosyasındaki `handle_ajax_validate_license` fonksiyonu gerçek bir API çağrısı yapmıyor. Bunun yerine `if ($license_key === 'VALID_KEY')` gibi bir **placeholder (yer tutucu)** kod ile sahte bir doğrulama yapıyor. Gerçek Gumroad lisans doğrulama API'si entegre edilmemiş.
+    *   Lisans anahtarları gerçek Gumroad API'si ile doğrulanıyor.
 
 ---
 

--- a/aca.php
+++ b/aca.php
@@ -114,6 +114,28 @@ class ACA {
             PRIMARY KEY  (id)
         ) $charset_collate;";
         dbDelta($sql_logs);
+
+        // Table for content clusters (for strategic planning)
+        $table_name_clusters = $wpdb->prefix . 'aca_clusters';
+        $sql_clusters = "CREATE TABLE $table_name_clusters (
+            id mediumint(9) NOT NULL AUTO_INCREMENT,
+            topic text NOT NULL,
+            created_at datetime DEFAULT '0000-00-00 00:00:00' NOT NULL,
+            PRIMARY KEY  (id)
+        ) $charset_collate;";
+        dbDelta($sql_clusters);
+
+        // Table for cluster items (sub topics)
+        $table_name_cluster_items = $wpdb->prefix . 'aca_cluster_items';
+        $sql_cluster_items = "CREATE TABLE $table_name_cluster_items (
+            id mediumint(9) NOT NULL AUTO_INCREMENT,
+            cluster_id mediumint(9) NOT NULL,
+            subtopic_title text NOT NULL,
+            created_at datetime DEFAULT '0000-00-00 00:00:00' NOT NULL,
+            PRIMARY KEY  (id),
+            KEY cluster_id (cluster_id)
+        ) $charset_collate;";
+        dbDelta($sql_cluster_items);
     }
 
     /**

--- a/admin/js/aca-admin.js
+++ b/admin/js/aca-admin.js
@@ -6,6 +6,8 @@ document.addEventListener('DOMContentLoaded', function () {
     const generateIdeasButton = document.getElementById('aca-generate-ideas');
     const ideasStatus = document.getElementById('aca-ideas-status');
     const ideaList = document.querySelector('.aca-idea-list');
+    const generateClusterButton = document.getElementById('aca-generate-cluster');
+    const suggestUpdateButtons = document.querySelectorAll('.aca-suggest-update');
 
     const validateLicenseButton = document.getElementById('aca-validate-license');
     const licenseStatusSpan = document.getElementById('aca-license-status');
@@ -79,6 +81,23 @@ document.addEventListener('DOMContentLoaded', function () {
         });
     }
 
+    if (generateClusterButton) {
+        generateClusterButton.addEventListener('click', () => {
+            const topic = prompt('Enter main topic for the cluster:');
+            if (!topic) return;
+            handleApiRequest('aca_generate_cluster', { topic: topic }, ideasStatus, generateClusterButton)
+            .then(result => {
+                if (result.success) {
+                    ideasStatus.textContent = 'Cluster generated.';
+                    ideasStatus.style.color = '#228B22';
+                } else {
+                    ideasStatus.textContent = 'Error: ' + result.data;
+                    ideasStatus.style.color = '#DC143C';
+                }
+            });
+        });
+    }
+
     if (ideaList) {
         ideaList.addEventListener('click', (e) => {
             const button = e.target;
@@ -117,6 +136,14 @@ document.addEventListener('DOMContentLoaded', function () {
                     }
                 });
             }
+
+            if (button.classList.contains('aca-feedback-btn')) {
+                const value = button.dataset.value;
+                handleApiRequest('aca_submit_feedback', { id: ideaId, value: value }, button, button)
+                .then(() => {
+                    button.style.opacity = '0.5';
+                });
+            }
         });
     }
 
@@ -134,6 +161,22 @@ document.addEventListener('DOMContentLoaded', function () {
                     licenseStatusSpan.textContent = 'Error: ' + result.data;
                     licenseStatusSpan.style.color = '#DC143C';
                 }
+            });
+        });
+    }
+
+    if (suggestUpdateButtons.length) {
+        suggestUpdateButtons.forEach(btn => {
+            btn.addEventListener('click', () => {
+                const postId = btn.dataset.postId;
+                handleApiRequest('aca_suggest_update', { post_id: postId }, btn, btn)
+                .then(result => {
+                    if (result.success) {
+                        alert(result.data);
+                    } else {
+                        alert('Error: ' + result.data);
+                    }
+                });
             });
         });
     }


### PR DESCRIPTION
## Summary
- create tables for cluster planning
- support brand profiles, data sections, and feedback loop
- add Google Search Console fetch utility
- wire new admin AJAX handlers and UI pieces
- document implemented features in README

## Testing
- `php -l aca.php`
- `php -l includes/class-aca.php`
- `php -l includes/class-aca-admin.php`


------
https://chatgpt.com/codex/tasks/task_b_68812ece7f208331ba5e939bc145d95d