### PR TITLE
Implement GDPR tools and freemium limits

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,7 +209,7 @@ Sıkça erişilen ancak nadiren değişen veriler (örn: Stil Kılavuzu) WordPre
 *   **Şeffaflık:** Kullanıcı, harici bir API kullanıldığı konusunda açıkça bilgilendirilir.
 *   **Veri Minimizasyonu:** API'ye sadece görevin gerektirdiği minimum veri gönderilir.
 *   **Veri Saklamama Politikası:** Analiz için alınan site içeriklerinin tam metni eklentinin veritabanında kalıcı olarak saklanmaz.
-*   **GDPR Araçları Uyumu:** Eklenti, WordPress'in "Kişisel Verileri Dışa Aktar/Sil" araçlarıyla uyumlu olacaktır.
+*   **GDPR Araçları Uyumu:** Eklenti, WordPress'in "Kişisel Verileri Dışa Aktar/Sil" araçlarıyla uyumludur.
 
 #### **11.3. Yasal Sorumluluk Reddi (Disclaimer)**
 Yönetim panelinde ve dokümantasyonda, üretilen tüm içeriğin bir "taslak" olduğu ve yayınlanmadan önce kullanıcı tarafından mutlaka kontrol edilmesi, düzenlenmesi ve doğrulanması gerektiği açıkça belirtilir. Nihai sorumluluğun kullanıcıya ait olduğu vurgulanır.

--- a/aca.php
+++ b/aca.php
@@ -35,6 +35,7 @@ require_once ACA_PLUGIN_DIR . 'includes/class-aca-dashboard.php';
 require_once ACA_PLUGIN_DIR . 'includes/class-aca.php';
 require_once ACA_PLUGIN_DIR . 'includes/class-aca-onboarding.php';
 require_once ACA_PLUGIN_DIR . 'includes/class-aca-cron.php';
+require_once ACA_PLUGIN_DIR . 'includes/class-aca-privacy.php';
 
 // Activation hook for onboarding and database setup
 register_activation_hook(__FILE__, ['ACA', 'activate']);
@@ -63,6 +64,9 @@ class ACA {
 
         // Initialize cron jobs
         new ACA_Cron();
+
+        // Register privacy hooks
+        ACA_Privacy::init();
     }
 
     /**

--- a/includes/class-aca-admin.php
+++ b/includes/class-aca-admin.php
@@ -515,8 +515,17 @@ class ACA_Admin {
     public function render_working_mode_field() {
         $options = get_option('aca_options');
         $current_mode = isset($options['working_mode']) ? $options['working_mode'] : 'manual';
+        if ( ! aca_is_pro() ) {
+            echo '<select name="aca_options[working_mode]" disabled>';
+            echo '<option value="manual" selected>' . esc_html__( 'Manual Mode', 'aca' ) . '</option>';
+            echo '</select>';
+            echo '<p class="description">' . esc_html__( 'Automation modes require ACA Pro.', 'aca' ) . '</p>';
+            echo '<input type="hidden" name="aca_options[working_mode]" value="manual">';
+            return;
+        }
+
         $modes = [
-            'manual' => __('Manual Mode', 'aca'),
+            'manual'    => __('Manual Mode', 'aca'),
             'semi-auto' => __('Semi-Automatic (Ideas & Approval)', 'aca'),
             'full-auto' => __('Fully Automatic (Draft Creation)', 'aca'),
         ];

--- a/includes/class-aca-cron.php
+++ b/includes/class-aca-cron.php
@@ -79,14 +79,14 @@ class ACA_Cron {
             ACA_Core::generate_ideas();
         } elseif ($working_mode === 'full-auto') {
             // In full-auto mode, generate ideas and then write drafts.
-            $ideas = ACA_Core::generate_ideas();
-            if (!is_wp_error($ideas) && !empty($ideas)) {
+            $idea_ids = ACA_Core::generate_ideas();
+            if (!is_wp_error($idea_ids) && !empty($idea_ids)) {
                 // Respect the generation limit.
                 $limit = $options['generation_limit'] ?? 1;
-                $ideas_to_write = array_slice($ideas, 0, $limit);
+                $ideas_to_write = array_slice($idea_ids, 0, $limit);
 
-                foreach ($ideas_to_write as $idea_title) {
-                    ACA_Core::write_post_draft($idea_title);
+                foreach ($ideas_to_write as $idea_id) {
+                    ACA_Core::write_post_draft($idea_id);
                 }
             }
         }
@@ -97,5 +97,7 @@ class ACA_Cron {
      */
     public function reset_api_usage_counter() {
         update_option('aca_api_usage_current_month', 0);
+        update_option('aca_idea_count_current_month', 0);
+        update_option('aca_draft_count_current_month', 0);
     }
 }

--- a/includes/class-aca-privacy.php
+++ b/includes/class-aca-privacy.php
@@ -1,0 +1,69 @@
+<?php
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+class ACA_Privacy {
+    public static function init() {
+        add_filter( 'wp_privacy_personal_data_exporters', [ __CLASS__, 'register_exporter' ] );
+        add_filter( 'wp_privacy_personal_data_erasers', [ __CLASS__, 'register_eraser' ] );
+    }
+
+    public static function register_exporter( $exporters ) {
+        $exporters['aca-data'] = [
+            'exporter_friendly_name' => __( 'ACA Settings', 'aca' ),
+            'callback'               => [ __CLASS__, 'export' ],
+        ];
+        return $exporters;
+    }
+
+    public static function export( $email_address, $page = 1 ) {
+        $data  = [];
+        $user  = get_user_by( 'email', $email_address );
+        if ( $user && user_can( $user, 'manage_aca_settings' ) ) {
+            $options  = get_option( 'aca_options', [] );
+            $license  = get_option( 'aca_license_key', '' );
+            $api_key  = get_option( 'aca_gemini_api_key', '' );
+            $data[] = [
+                'name'  => __( 'ACA Options', 'aca' ),
+                'value' => wp_json_encode( $options ),
+            ];
+            if ( $license ) {
+                $data[] = [ 'name' => __( 'License Key', 'aca' ), 'value' => $license ];
+            }
+            if ( $api_key ) {
+                $data[] = [ 'name' => __( 'Encrypted API Key', 'aca' ), 'value' => $api_key ];
+            }
+        }
+        return [
+            'data' => $data,
+            'done' => true,
+        ];
+    }
+
+    public static function register_eraser( $erasers ) {
+        $erasers['aca-data'] = [
+            'eraser_friendly_name' => __( 'ACA Settings', 'aca' ),
+            'callback'             => [ __CLASS__, 'erase' ],
+        ];
+        return $erasers;
+    }
+
+    public static function erase( $email_address, $page = 1 ) {
+        $removed = false;
+        $user    = get_user_by( 'email', $email_address );
+        if ( $user && user_can( $user, 'manage_aca_settings' ) ) {
+            delete_option( 'aca_gemini_api_key' );
+            delete_option( 'aca_license_key' );
+            delete_option( 'aca_options' );
+            delete_option( 'aca_is_pro_active' );
+            $removed = true;
+        }
+        return [
+            'items_removed'  => $removed,
+            'items_retained' => false,
+            'messages'       => [],
+            'done'           => true,
+        ];
+    }
+}


### PR DESCRIPTION
## Summary
- add privacy exporter & eraser for GDPR compliance
- enforce freemium limits for ideas/drafts
- reset counters monthly
- disable automation modes for free users
- update README to reflect GDPR support

## Testing
- `php -l includes/class-aca-privacy.php`
- `php -l includes/class-aca.php`
- `php -l includes/class-aca-admin.php`
- `php -l includes/class-aca-cron.php`
- `php -l aca.php`
- `composer validate --no-check-lock`

------
https://chatgpt.com/codex/tasks/task_b_68813d13e8488331a77b3ed8f8ba7f62