### PR TITLE
Implement missing features from README

### DIFF
--- a/includes/class-aca-dashboard.php
+++ b/includes/class-aca-dashboard.php
@@ -64,7 +64,10 @@ class ACA_Dashboard {
                 echo '<li data-id="' . $idea->id . '">' . esc_html($idea->idea_title) .
                      ' <button class="button-primary aca-write-draft" data-id="' . $idea->id . '">' . __('Write Draft', 'aca') . '</button>' .
                      ' <span class="aca-draft-status"></span>' .
-                     ' <button class="button-secondary aca-reject-idea" data-id="' . $idea->id . '">' . __('Reject', 'aca') . '</button></li>';
+                     ' <button class="button-secondary aca-reject-idea" data-id="' . $idea->id . '">' . __('Reject', 'aca') . '</button>' .
+                     ' <button class="button aca-feedback-btn" data-value="1">👍</button>' .
+                     ' <button class="button aca-feedback-btn" data-value="-1">👎</button>' .
+                     '</li>';
             }
             echo '</ul>';
         } else {


### PR DESCRIPTION
## Summary
- implement style guide generation logic
- implement idea generation logic
- implement draft writing with brand profiles
- add brand voice profile setting and plagiarism meta box
- support feedback buttons in idea list

## Testing
- `composer install`
- `php -l includes/class-aca.php`
- `php -l includes/class-aca-admin.php`
- `php -l includes/class-aca-dashboard.php`
- `find . -name '*.php' -print0 | xargs -0 -n1 php -l`

------
https://chatgpt.com/codex/tasks/task_b_688140ecc30883319cf573d2c7ece093