### PR TITLE
Implement DALL‑E images & admin notifications

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,7 +160,7 @@ WordPress yönetici menüsünde "ACA" adıyla yer alacak ana panel, aşağıdaki
 *   **Hızlı Eylemler:** "Şimdi Yeni Fikir Üret", "Stil Kılavuzunu Manuel Güncelle" gibi kısayol butonları.
 
 #### **8.4. Bildirim Merkezi**
-API anahtarı geçersiz olduğunda, API kullanım limiti %80'e ulaştığında, yeni fikirler onaya hazır olduğunda (isteğe bağlı) veya bir içerik oluşturma işlemi başarısız olduğunda kullanıcıyı bilgilendirir.
+API anahtarı geçersiz olduğunda, API kullanım limiti %80'e ulaştığında, yeni fikirler onaya hazır olduğunda (isteğe bağlı) veya bir içerik oluşturma işlemi başarısız olduğunda kullanıcıyı bilgilendirir. Bu sürümde, bekleyen fikir sayısı ve son hatalar için yönetici bildirimleri eklendi.
 
 ---
 
@@ -226,7 +226,7 @@ Bu bölümdeki kritik özelliklerin bir kısmı bu sürümle birlikte eklenmişt
     *   **Kaynak Göstermeli İçerik:** `write_post_draft` fonksiyonunda kaynak linkleri taslak içeriğine otomatik olarak ekleniyor.
 
 *   **İçerik Zenginleştirme:**
-    *   **Akıllı Öne Çıkan Görsel:** Unsplash entegrasyonu eklenerek, taslaklara otomatik görsel atanabiliyor.
+    *   **Akıllı Öne Çıkan Görsel:** Unsplash ve Pexels entegrasyonu eklenerek taslaklara otomatik görsel atanabiliyor. DALL-E 3 ile özel görsel üretme seçeneği de eklendi.
     *   **Otomatik İç Linkleme:** Yeni taslaklara mevcut içerikten rastgele iç linkler ekleyen temel bir mekanizma eklendi.
     *   **Veri Destekli Bölümler:** Taslak sonuna güncel istatistikler veya tablolar ekleyen özellik eklendi.
 

--- a/includes/class-aca.php
+++ b/includes/class-aca.php
@@ -431,6 +431,37 @@ class ACA_Core {
                 return;
             }
             $url = $body['photos'][0]['src']['large'];
+        } elseif ($provider === 'dalle') {
+            if ( ! aca_is_pro() ) {
+                return;
+            }
+            $options = get_option('aca_options');
+            $api_key = $options['openai_api_key'] ?? '';
+            if ( empty( $api_key ) ) {
+                return;
+            }
+            $endpoint = 'https://api.openai.com/v1/images/generations';
+            $response = wp_remote_post( $endpoint, [
+                'headers' => [
+                    'Authorization' => 'Bearer ' . $api_key,
+                    'Content-Type'  => 'application/json',
+                ],
+                'body'    => wp_json_encode([
+                    'model'  => 'dall-e-3',
+                    'prompt' => $query,
+                    'n'      => 1,
+                    'size'   => '1024x1024',
+                ]),
+                'timeout' => 60,
+            ] );
+            if ( is_wp_error( $response ) ) {
+                return;
+            }
+            $body = json_decode( wp_remote_retrieve_body( $response ), true );
+            if ( empty( $body['data'][0]['url'] ) ) {
+                return;
+            }
+            $url = $body['data'][0]['url'];
         } else {
             return;
         }


### PR DESCRIPTION
## Summary
- support DALL‑E 3 for featured images
- add OpenAI API key field
- show notification for pending ideas and recent errors
- update README with new features

## Testing
- `composer install`
- `php -l includes/class-aca-admin.php`
- `php -l includes/class-aca.php`
- `php -l aca.php`
- `php -l includes/api.php`
- `php -l includes/class-aca-dashboard.php`
- `php -l includes/class-aca-cron.php`
- `php -l includes/class-aca-onboarding.php`
- `php -l includes/class-aca-privacy.php`


------
https://chatgpt.com/codex/tasks/task_b_68814686121c8331a8e04cb5121b99f0