### PR TITLE
Implement GSC idea generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -237,7 +237,7 @@ Bu bölümdeki stratejik özelliklerin de büyük çoğunluğu uygulanmamıştı
 *   **Stratejik Planlama Araçları:**
     *   **İçerik Kümesi (Content Cluster) Planlayıcısı:** Basit bir AI tabanlı planlayıcı eklendi.
     *   **İçerik Güncelleme Asistanı:** Yazılar için güncelleme önerileri sunan yardımcı fonksiyon eklendi.
-    *   **Google Search Console Entegrasyonu:** API anahtarı ile temel arama sorguları çekilebiliyor.
+    *   **Google Search Console Entegrasyonu:** API anahtarı ile temel arama sorguları çekiliyor ve henüz karşılanmamış sorgulardan otomatik içerik fikirleri üretiliyor.
 
 *   **Gelişmiş Uyarlanabilirlik:**
     *   **Marka Sesi Profilleri:** Birden fazla stil kılavuzu kaydedip içerik üretiminde kullanmak mümkün.

--- a/admin/js/aca-admin.js
+++ b/admin/js/aca-admin.js
@@ -9,6 +9,7 @@ document.addEventListener('DOMContentLoaded', function () {
     const generateClusterButton = document.getElementById('aca-generate-cluster');
     const suggestUpdateButtons = document.querySelectorAll('.aca-suggest-update');
     const fetchGSCButton = document.getElementById('aca-fetch-gsc');
+    const generateGSCIdeasButton = document.getElementById('aca-generate-gsc-ideas');
     const gscResults = document.getElementById('aca-gsc-results');
 
     const validateLicenseButton = document.getElementById('aca-validate-license');
@@ -204,6 +205,22 @@ document.addEventListener('DOMContentLoaded', function () {
                     }
                 } else {
                     gscResults.textContent = 'Error: ' + result.data;
+                }
+            });
+        });
+    }
+
+    if (generateGSCIdeasButton) {
+        generateGSCIdeasButton.addEventListener('click', () => {
+            handleApiRequest('aca_generate_gsc_ideas', {}, ideasStatus, generateGSCIdeasButton)
+            .then(result => {
+                if (result.success) {
+                    ideasStatus.textContent = result.data.message;
+                    ideasStatus.style.color = '#228B22';
+                    setTimeout(() => location.reload(), 1000);
+                } else {
+                    ideasStatus.textContent = 'Error: ' + result.data;
+                    ideasStatus.style.color = '#DC143C';
                 }
             });
         });

--- a/includes/class-aca-admin.php
+++ b/includes/class-aca-admin.php
@@ -32,6 +32,7 @@ class ACA_Admin {
         add_action('wp_ajax_aca_submit_feedback', [$this, 'handle_ajax_submit_feedback']);
         add_action('wp_ajax_aca_suggest_update', [$this, 'handle_ajax_suggest_update']);
         add_action('wp_ajax_aca_fetch_gsc_data', [$this, 'handle_ajax_fetch_gsc_data']);
+        add_action('wp_ajax_aca_generate_gsc_ideas', [$this, 'handle_ajax_generate_gsc_ideas']);
         add_action('admin_notices', [$this, 'display_admin_notices']);
         add_action('add_meta_boxes', [$this, 'add_plagiarism_metabox']);
     }
@@ -323,6 +324,26 @@ class ACA_Admin {
             wp_send_json_error($result->get_error_message());
         } else {
             wp_send_json_success($result);
+        }
+    }
+
+    /**
+     * Generate ideas based on Search Console queries.
+     */
+    public function handle_ajax_generate_gsc_ideas() {
+        check_ajax_referer('aca_admin_nonce', 'nonce');
+
+        if ( ! current_user_can('manage_aca_settings') ) {
+            wp_send_json_error(esc_html__('You do not have permission to do this.', 'aca'));
+        }
+
+        $result = ACA_Core::generate_ideas_from_gsc();
+
+        if (is_wp_error($result)) {
+            wp_send_json_error($result->get_error_message());
+        } else {
+            $message = sprintf(esc_html(_n('%d new idea generated.', '%d new ideas generated.', count($result), 'aca')), count($result));
+            wp_send_json_success(['message' => $message]);
         }
     }
 

--- a/includes/class-aca-dashboard.php
+++ b/includes/class-aca-dashboard.php
@@ -101,7 +101,8 @@ class ACA_Dashboard {
 
     private static function render_gsc_section() {
         echo '<h2>' . __( 'Top Search Queries', 'aca' ) . '</h2>';
-        echo '<button class="button" id="aca-fetch-gsc">' . __( 'Fetch Queries', 'aca' ) . '</button>';
-        echo '<div id="aca-gsc-results"></div>';
+        echo '<button class="button" id="aca-fetch-gsc">' . __( 'Fetch Queries', 'aca' ) . '</button> ';
+        echo '<button class="button" id="aca-generate-gsc-ideas">' . __( 'Generate Ideas', 'aca' ) . '</button>';
+        echo '<div id="aca-gsc-results" style="margin-top:10px;"></div>';
     }
 }


### PR DESCRIPTION
## Summary
- generate new post ideas from Google Search Console queries
- expose AJAX handler to trigger it from the dashboard
- add dashboard button and JS for generating ideas
- document Search Console idea generation

## Testing
- `php -l includes/class-aca.php`
- `php -l includes/class-aca-admin.php`
- `php -l includes/class-aca-dashboard.php`
- `node -e "require('fs').readFileSync('admin/js/aca-admin.js'); console.log('js ok');"`
- `composer validate --no-check-all --strict`

------
https://chatgpt.com/codex/tasks/task_b_68814b23c5cc83319775495fc37f3dbf