### PR TITLE
Update Gemini API endpoint

### DIFF
--- a/includes/api.php
+++ b/includes/api.php
@@ -81,7 +81,7 @@ function aca_call_gemini_api( $prompt, $system_instruction = '', $api_args = [] 
 		return new WP_Error( 'api_key_missing', __( 'Google Gemini API key is not set.', 'aca' ) );
 	}
 
-	$api_url = 'https://generativelanguage.googleapis.com/v1beta/models/gemini-pro:generateContent?key=' . $api_key;
+        $api_url = 'https://generativelanguage.googleapis.com/v1beta/models/gemini-2.0-flash:generateContent?key=' . $api_key;
 
     $contents = [
         [


### PR DESCRIPTION
## Summary
- update the Gemini API URL to use `gemini-2.0-flash`

## Testing
- `php -l includes/api.php`

------
https://chatgpt.com/codex/tasks/task_b_68814e2292688331ba79457b739c03a3