### PR TITLE
Fix API key handling and improve license checks

### DIFF
--- a/includes/licensing.php
+++ b/includes/licensing.php
@@ -1,0 +1,57 @@
+<?php
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+/**
+ * Check license status with Gumroad.
+ *
+ * @param bool $force Force verification even if cached.
+ * @return bool True if license is valid, false otherwise.
+ */
+function aca_maybe_check_license( $force = false ) {
+    $cached = get_transient( 'aca_license_status' );
+    if ( false !== $cached && ! $force ) {
+        return $cached === 'valid';
+    }
+
+    $license_key = get_option( 'aca_license_key' );
+    if ( empty( $license_key ) ) {
+        set_transient( 'aca_license_status', 'invalid', WEEK_IN_SECONDS );
+        update_option( 'aca_is_pro_active', 'false' );
+        return false;
+    }
+
+    $api_url  = 'https://api.gumroad.com/v2/licenses/verify';
+    $response = wp_remote_post( $api_url, [
+        'method'  => 'POST',
+        'timeout' => 15,
+        'body'    => [
+            'product_id'  => ACA_GUMROAD_PRODUCT_ID,
+            'license_key' => $license_key,
+        ],
+    ] );
+
+    if ( is_wp_error( $response ) ) {
+        // Fail open: keep current status if API unreachable.
+        return get_option( 'aca_is_pro_active' ) === 'true';
+    }
+
+    $body  = json_decode( wp_remote_retrieve_body( $response ), true );
+    $valid = isset( $body['success'] ) && true === $body['success'] && empty( $body['purchase']['refunded'] ) && empty( $body['purchase']['chargebacked'] );
+
+    set_transient( 'aca_license_status', $valid ? 'valid' : 'invalid', WEEK_IN_SECONDS );
+
+    if ( $valid ) {
+        update_option( 'aca_is_pro_active', 'true' );
+        update_option( 'aca_license_data', $body['purchase'] );
+        $sale_time   = isset( $body['purchase']['sale_timestamp'] ) ? strtotime( $body['purchase']['sale_timestamp'] ) : time();
+        $valid_until = $sale_time + YEAR_IN_SECONDS;
+        update_option( 'aca_license_valid_until', $valid_until );
+    } else {
+        update_option( 'aca_is_pro_active', 'false' );
+        delete_option( 'aca_license_valid_until' );
+    }
+
+    return $valid;
+}


### PR DESCRIPTION
## Summary
- preserve existing API key when settings form is saved with blank field
- store Gumroad license expiration and status information
- add scheduled license verification and cleanup on plugin deactivation
- check license validity in `aca_is_pro()`

## Testing
- `composer install`
- `php -l includes/class-aca-admin.php`
- `php -l includes/class-aca-cron.php`
- `php -l includes/licensing.php`
- `php -l aca.php`


------
https://chatgpt.com/codex/tasks/task_b_688152b48e7c83318826fdf846df54bc