### PR TITLE
Improve ACA internal logic and UI

### DIFF
--- a/aca.php
+++ b/aca.php
@@ -39,7 +39,7 @@ require_once ACA_PLUGIN_DIR . 'includes/class-aca-privacy.php';
 require_once ACA_PLUGIN_DIR . 'includes/licensing.php';
 
 // Activation hook for onboarding and database setup
-register_activation_hook(__FILE__, ['ACA', 'activate']);
+register_activation_hook(__FILE__, ['ACA_Bootstrap', 'activate']);
 register_deactivation_hook(__FILE__, 'aca_deactivate');
 
 function aca_deactivate() {
@@ -57,9 +57,9 @@ function aca_deactivate() {
 }
 
 /**
- * Main ACA Class
+ * ACA Bootstrap Class
  */
-class ACA {
+class ACA_Bootstrap {
 
     /**
      * Constructor.
@@ -205,4 +205,4 @@ function aca_is_pro() {
 }
 
 // Instantiate the main class
-new ACA();
+new ACA_Bootstrap();

--- a/admin/js/aca-admin.js
+++ b/admin/js/aca-admin.js
@@ -7,6 +7,8 @@ document.addEventListener('DOMContentLoaded', function () {
     const ideasStatus = document.getElementById('aca-ideas-status');
     const ideaList = document.querySelector('.aca-idea-list');
     const generateClusterButton = document.getElementById('aca-generate-cluster');
+    const clusterTopicInput = document.getElementById('aca-cluster-topic');
+    const clusterStatus = document.getElementById('aca-cluster-status');
     const suggestUpdateButtons = document.querySelectorAll('.aca-suggest-update');
     const fetchGSCButton = document.getElementById('aca-fetch-gsc');
     const generateGSCIdeasButton = document.getElementById('aca-generate-gsc-ideas');
@@ -32,7 +34,17 @@ document.addEventListener('DOMContentLoaded', function () {
             method: 'POST',
             body: formData
         })
-        .then(response => response.json())
+        .then(response => {
+            if (!response.ok) {
+                throw new Error('HTTP ' + response.status);
+            }
+            return response.json();
+        })
+        .catch(error => {
+            statusElement.textContent = 'Network error: ' + error.message;
+            statusElement.style.color = '#DC143C';
+            return { success: false, data: error.message };
+        })
         .finally(() => {
             if (buttonElement) buttonElement.disabled = false;
         });
@@ -86,16 +98,19 @@ document.addEventListener('DOMContentLoaded', function () {
 
     if (generateClusterButton) {
         generateClusterButton.addEventListener('click', () => {
-            const topic = prompt('Enter main topic for the cluster:');
-            if (!topic) return;
-            handleApiRequest('aca_generate_cluster', { topic: topic }, ideasStatus, generateClusterButton)
+            const topic = clusterTopicInput ? clusterTopicInput.value.trim() : '';
+            if (!topic) {
+                alert('Please enter a topic');
+                return;
+            }
+            handleApiRequest('aca_generate_cluster', { topic: topic }, clusterStatus, generateClusterButton)
             .then(result => {
                 if (result.success) {
-                    ideasStatus.textContent = 'Cluster generated.';
-                    ideasStatus.style.color = '#228B22';
+                    clusterStatus.textContent = 'Cluster generated.';
+                    clusterStatus.style.color = '#228B22';
                 } else {
-                    ideasStatus.textContent = 'Error: ' + result.data;
-                    ideasStatus.style.color = '#DC143C';
+                    clusterStatus.textContent = 'Error: ' + result.data;
+                    clusterStatus.style.color = '#DC143C';
                 }
             });
         });

--- a/includes/class-aca-cron.php
+++ b/includes/class-aca-cron.php
@@ -107,17 +107,17 @@ class ACA_Cron {
 
         if ($working_mode === 'semi-auto') {
             // In semi-auto mode, only generate ideas.
-            ACA_Core::generate_ideas();
+            ACA_Engine::generate_ideas();
         } elseif ($working_mode === 'full-auto') {
             // In full-auto mode, generate ideas and then write drafts.
-            $idea_ids = ACA_Core::generate_ideas();
+            $idea_ids = ACA_Engine::generate_ideas();
             if (!is_wp_error($idea_ids) && !empty($idea_ids)) {
                 // Respect the generation limit.
                 $limit = $options['generation_limit'] ?? 1;
                 $ideas_to_write = array_slice($idea_ids, 0, $limit);
 
                 foreach ($ideas_to_write as $idea_id) {
-                    ACA_Core::write_post_draft($idea_id);
+                    ACA_Engine::write_post_draft($idea_id);
                 }
             }
         }
@@ -136,7 +136,7 @@ class ACA_Cron {
      * Generate style guide periodically.
      */
     public function generate_style_guide() {
-        ACA_Core::generate_style_guide();
+        ACA_Engine::generate_style_guide();
     }
 
     /**

--- a/includes/class-aca-dashboard.php
+++ b/includes/class-aca-dashboard.php
@@ -28,6 +28,9 @@ class ACA_Dashboard {
         // Idea Stream Section
         self::render_idea_stream_section();
 
+        // Cluster Planner Section
+        self::render_cluster_planner_section();
+
         // Recent Activity Section
         self::render_recent_activity_section();
 
@@ -76,6 +79,13 @@ class ACA_Dashboard {
 
         echo '<button class="button-primary" id="aca-generate-ideas">' . __( 'Generate New Ideas Manually', 'aca' ) . '</button>';
         echo '<span id="aca-ideas-status"></span>';
+    }
+
+    private static function render_cluster_planner_section() {
+        echo '<h2>' . __( 'Content Cluster Planner', 'aca' ) . '</h2>';
+        echo '<input type="text" id="aca-cluster-topic" placeholder="' . esc_attr__( 'Main Topic', 'aca' ) . '" /> ';
+        echo '<button class="button" id="aca-generate-cluster">' . __( 'Generate Cluster Ideas', 'aca' ) . '</button> ';
+        echo '<span id="aca-cluster-status"></span>';
     }
 
     private static function render_recent_activity_section() {

--- a/includes/class-aca-onboarding.php
+++ b/includes/class-aca-onboarding.php
@@ -58,7 +58,7 @@ class ACA_Onboarding {
                 
                 // Complete onboarding
                 update_option('aca_onboarding_complete', true);
-                ACA_Core::add_log('Onboarding completed successfully.', 'success');
+                ACA_Engine::add_log('Onboarding completed successfully.', 'success');
                 wp_redirect(admin_url('admin.php?page=aca'));
                 exit;
             }


### PR DESCRIPTION
## Summary
- rename core classes for clarity
- parse AI responses from JSON with legacy fallback
- build smarter internal linking using keyword search
- add cluster planner UI and update assistant links
- load admin script on post list pages with network error handling

## Testing
- `composer install`
- `php -l aca.php`
- `php -l includes/class-aca.php`
- `php -l includes/class-aca-dashboard.php`
- `php -l includes/class-aca-admin.php`
- `php -l includes/class-aca-cron.php`
- `php -l includes/class-aca-onboarding.php`


------
https://chatgpt.com/codex/tasks/task_b_6881551088648331b169de1aaade02b3